### PR TITLE
Handle if Webpurify API response doesn't include `found` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
-## [0.1.1] - 2023-04-28
+## [0.1.2] - 2023-05-30
+### Fixed
+- [PR#7](https://github.com/EmbarkStudios/tame-webpurify/pull/7) Handle if Webpurify API response doesn't include `found` field.
 
 ## [0.1.1] - 2023-04-27
 ### Added
@@ -21,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release - support for WebPurify `check` and `replace` methods
 
 <!-- next-url -->
-[Unreleased]: https://github.com/EmbarkStudios//compare/0.1.1...HEAD
-[0.1.1]: https://github.com/EmbarkStudios/tame-webpurify/compare/0.1.1...0.1.1
+[Unreleased]: https://github.com/EmbarkStudios//compare/0.1.2...HEAD
+[0.1.2]: https://github.com/EmbarkStudios/tame-webpurify/compare/0.1.1...0.1.2
 [0.1.1]: https://github.com/EmbarkStudios/tame-webpurify/compare/0.1.0...0.1.1
 [0.1.0]: https://github.com/EmbarkStudios/tame-webpurify/releases/tag/0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tame-webpurify"
 description = "Simple Rust client for the WebPurify REST API"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
     "Embark <opensource@embark-studios.com>",
     "Mathias Tervo <mathias.tervo@embark-studios.com>"

--- a/examples/check.rs
+++ b/examples/check.rs
@@ -17,15 +17,15 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
     // webpurify should filter out profanities as well as phone numbers and other contact info
     let text = "fuck you man! call me at +46123123123 or email me at some.name@example.com";
 
-    let request = client::profanity_replace_request(api_key, region, text, "*")?;
+    let request = client::profanity_check_request(api_key, region, text)?;
     println!("{:?}", &request.uri());
 
     let http_client = reqwest::Client::new();
     let response = common::http_send(&http_client, request).await?;
 
-    let result = client::profanity_replace_result(response)?;
+    let result = client::profanity_check_result(response)?;
 
-    println!("{:?}", &result);
+    println!("Found {:?} bad words", &result);
 
     Ok(())
 }

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -1,0 +1,19 @@
+use bytes::Bytes;
+use http::Request;
+use std::error::Error;
+
+/// Return reqwest response
+pub async fn http_send<Body: Into<reqwest::Body>>(
+    http_client: &reqwest::Client,
+    request: Request<Body>,
+) -> Result<http::Response<Bytes>, Box<dyn Error>> {
+    // Make the request
+    let mut response = http_client.execute(request.try_into()?).await?;
+
+    // Convert to http::Response
+    let mut builder = http::Response::builder()
+        .status(response.status())
+        .version(response.version());
+    std::mem::swap(builder.headers_mut().unwrap(), response.headers_mut());
+    Ok(builder.body(response.bytes().await?)?)
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -269,7 +269,7 @@ mod test {
     }
 
     #[test]
-    fn check_result_mssing_found() -> Result<(), Box<dyn Error>> {
+    fn check_result_missing_found() -> Result<(), Box<dyn Error>> {
         let body = format!("{{\"rsp\":{{\"@attributes\":{{\"stat\":\"ok\",\"rsp\":\"0.0072040557861328\"}},\"method\":\"webpurify.live.check\",\"format\":\"rest\",\"api_key\":\"123\"}}}}");
         let response = Response::builder()
             .status(StatusCode::OK)

--- a/src/client.rs
+++ b/src/client.rs
@@ -191,13 +191,13 @@ where
 {
     let response = parse_response(response)?;
 
-    let check = response
+    let check: u32 = response
         .rsp
         .found
         .ok_or_else(|| ResponseError::MissingField("found".to_owned()))
         .and_then(|found| {
             found
-                .parse::<u32>()
+                .parse()
                 .map_err(|_err| ResponseError::InvalidField("found".to_owned()))
         })?;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -185,7 +185,10 @@ where
 ///
 /// * `response` - a response object from the `WebPurify` `check` API call
 ///
-pub fn profanity_check_result(response: Response<Vec<u8>>) -> Result<bool, ResponseError> {
+pub fn profanity_check_result<T>(response: Response<T>) -> Result<bool, ResponseError>
+where
+    T: AsRef<[u8]>,
+{
     let response = parse_response(response)?;
 
     let check = response

--- a/src/client.rs
+++ b/src/client.rs
@@ -163,7 +163,7 @@ struct ApiResponse {
 
 #[derive(serde::Deserialize)]
 struct ApiResponseRsp {
-    found: String,
+    found: Option<String>,
     text: Option<String>,
 }
 
@@ -191,8 +191,12 @@ pub fn profanity_check_result(response: Response<Vec<u8>>) -> Result<bool, Respo
     let check = response
         .rsp
         .found
-        .parse::<u32>()
-        .map_err(|_err| ResponseError::InvalidField("found".to_owned()))?;
+        .ok_or_else(|| ResponseError::MissingField("found".to_owned()))
+        .and_then(|found| {
+            found
+                .parse::<u32>()
+                .map_err(|_err| ResponseError::InvalidField("found".to_owned()))
+        })?;
 
     Ok(check > 0)
 }
@@ -262,6 +266,17 @@ mod test {
     }
 
     #[test]
+    fn check_result_mssing_found() -> Result<(), Box<dyn Error>> {
+        let body = format!("{{\"rsp\":{{\"@attributes\":{{\"stat\":\"ok\",\"rsp\":\"0.0072040557861328\"}},\"method\":\"webpurify.live.check\",\"format\":\"rest\",\"api_key\":\"123\"}}}}");
+        let response = Response::builder()
+            .status(StatusCode::OK)
+            .body(body.as_bytes().to_vec());
+        let result = client::profanity_check_result(response?);
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
     fn replace_request() {
         let region = client::Region::Europe;
         let res_req = client::profanity_replace_request("abcd", region, "hi there", "*");
@@ -274,6 +289,18 @@ mod test {
     #[test]
     fn replace_result() -> Result<(), Box<dyn Error>> {
         let body = b"{\"rsp\":{\"@attributes\":{\"stat\":\"ok\",\"rsp\":\"0.018898963928223\"},\"method\":\"webpurify.live.replace\",\"format\":\"rest\",\"found\":\"3\",\"text\":\"foo\",\"api_key\":\"123\"}}";
+        let response = Response::builder()
+            .status(StatusCode::OK)
+            .body((*body).into_iter().collect::<Vec<_>>())?;
+        let result = client::profanity_replace_result(response)?;
+
+        assert_eq!(result, "foo".to_owned());
+        Ok(())
+    }
+
+    #[test]
+    fn replace_result_missing_found() -> Result<(), Box<dyn Error>> {
+        let body = b"{\"rsp\":{\"@attributes\":{\"stat\":\"ok\",\"rsp\":\"0.018898963928223\"},\"method\":\"webpurify.live.replace\",\"format\":\"rest\",\"text\":\"foo\",\"api_key\":\"123\"}}";
         let response = Response::builder()
             .status(StatusCode::OK)
             .body((*body).into_iter().collect::<Vec<_>>())?;


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

For some reason responses from the Webpurify API doesn't include the field `found` anymore. It might be a temporary thing but this change make the replace method work at least as it doesn't require that field. 
The check method however requires that field and won't function until it returns to the response.

