### PR TITLE
Add example for `check` functionality

### DIFF
--- a/examples/check.rs
+++ b/examples/check.rs
@@ -17,15 +17,15 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
     // webpurify should filter out profanities as well as phone numbers and other contact info
     let text = "fuck you man! call me at +46123123123 or email me at some.name@example.com";
 
-    let request = client::profanity_replace_request(api_key, region, text, "*")?;
+    let request = client::profanity_check_request(api_key, region, text)?;
     println!("{:?}", &request.uri());
 
     let http_client = reqwest::Client::new();
     let response = common::http_send(&http_client, request).await?;
 
-    let result = client::profanity_replace_result(response)?;
+    let result = client::profanity_check_result(response)?;
 
-    println!("{:?}", &result);
+    println!("Found {:?} bad words", &result);
 
     Ok(())
 }

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -1,0 +1,19 @@
+use bytes::Bytes;
+use http::Request;
+use std::error::Error;
+
+/// Return reqwest response
+pub async fn http_send<Body: Into<reqwest::Body>>(
+    http_client: &reqwest::Client,
+    request: Request<Body>,
+) -> Result<http::Response<Bytes>, Box<dyn Error>> {
+    // Make the request
+    let mut response = http_client.execute(request.try_into()?).await?;
+
+    // Convert to http::Response
+    let mut builder = http::Response::builder()
+        .status(response.status())
+        .version(response.version());
+    std::mem::swap(builder.headers_mut().unwrap(), response.headers_mut());
+    Ok(builder.body(response.bytes().await?)?)
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -191,13 +191,13 @@ where
 {
     let response = parse_response(response)?;
 
-    let check = response
+    let check: u32 = response
         .rsp
         .found
         .ok_or_else(|| ResponseError::MissingField("found".to_owned()))
         .and_then(|found| {
             found
-                .parse::<u32>()
+                .parse()
                 .map_err(|_err| ResponseError::InvalidField("found".to_owned()))
         })?;
 


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Add example for WebPurify `check` method

`cargo run --example check -- --apikey <some-api-key`

Extracted the `http_send` function into a shared mod.

### Related Issues

Extension proposal to PR https://github.com/EmbarkStudios/tame-webpurify/pull/7/
