### PR TITLE
Return the number of profanities found in the `check` response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 ### Fixed
-- [PR#13](https://github.com/EmbarkStudios/tame-webpurify/pull/12) Return the number of profanities found in the `check` response.
+- [PR#13](https://github.com/EmbarkStudios/tame-webpurify/pull/13) Return the number of profanities found in the `check` response.
 
 ## [0.1.2] - 2023-05-31
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#12](https://github.com/EmbarkStudios/tame-webpurify/pull/12) Return the number of profanities found in the `check` response.
 
 ## [0.1.2] - 2023-05-31
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 ### Fixed
-- [PR#12](https://github.com/EmbarkStudios/tame-webpurify/pull/12) Return the number of profanities found in the `check` response.
+- [PR#13](https://github.com/EmbarkStudios/tame-webpurify/pull/12) Return the number of profanities found in the `check` response.
 
 ## [0.1.2] - 2023-05-31
 ### Added

--- a/src/client.rs
+++ b/src/client.rs
@@ -253,20 +253,19 @@ where
 
     Ok(api_response)
 }
-
-/// Returns true if `WebPurify` flagged a request to contain profanities, PII, etc
+/// Returns the number of profanities, PII etc `WebPurify` matched in the input string.
 ///
 /// # Arguments
 ///
 /// * `response` - a response object from the `WebPurify` `check` API call
 ///
-pub fn profanity_check_result<T>(response: Response<T>) -> Result<bool, ResponseError>
+pub fn profanity_check_result<T>(response: Response<T>) -> Result<u32, ResponseError>
 where
     T: AsRef<[u8]>,
 {
     let response = parse_response(response, Method::Check)?;
 
-    let check: u32 = response
+    let found: u32 = response
         .rsp
         .found
         .ok_or_else(|| ResponseError::MissingField("found".to_owned()))
@@ -276,7 +275,7 @@ where
                 .map_err(|_err| ResponseError::InvalidField("found".to_owned()))
         })?;
 
-    Ok(check > 0)
+    Ok(found)
 }
 
 /// Returns the sanitized string from a response object.
@@ -337,9 +336,9 @@ mod test {
                 .body(body.as_bytes().to_vec())
         };
         let result = client::profanity_check_result(response_found(3)?)?;
-        assert!(result);
+        assert_eq!(result, 3);
         let result = client::profanity_check_result(response_found(0)?)?;
-        assert!(!result);
+        assert_eq!(result, 0);
         Ok(())
     }
 


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Change return value of `profanity_check_result` so that number of profanities found is returned instead of just a `bool`. This also is more true to what is described here https://github.com/EmbarkStudios/tame-webpurify/blob/7df3aa301f8960858a64eb48a29b8ddd48b1bedf/src/client.rs#L115 for `profanity_check_request`.

This will be and api breaking change.
