### PR TITLE
Smart screen functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
-
 ## [Unreleased] - ReleaseDate
+
+## [0.1.1] - 2023-04-28
 
 ## [0.1.1] - 2023-04-27
 ### Added
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release - support for WebPurify `check` and `replace` methods
 
 <!-- next-url -->
-[Unreleased]: https://github.com/EmbarkStudios/tame-webpurify/compare/0.1.1...HEAD
+[Unreleased]: https://github.com/EmbarkStudios//compare/0.1.1...HEAD
+[0.1.1]: https://github.com/EmbarkStudios/tame-webpurify/compare/0.1.1...0.1.1
 [0.1.1]: https://github.com/EmbarkStudios/tame-webpurify/compare/0.1.0...0.1.1
 [0.1.0]: https://github.com/EmbarkStudios/tame-webpurify/releases/tag/0.1.0

--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ Please be advised that the source code will contain some swearing etc. Can't tes
 without actually acting like a jerk.
 
 See the example code on how to use it `tame-webpurify` together with [reqwest](https://crates.io/crates/reqwest)
+
 ## Examples
 
 Build and run the provided example:
 
 ```bash
-$ cargo run --example profanity -- --apikey <your-webpurify-api-key>
+$ cargo run --example replace -- --apikey <your-webpurify-api-key>
 => 
  
 {
@@ -58,6 +59,8 @@ $ cargo run --example profanity -- --apikey <your-webpurify-api-key>
   }
 }
 ```
+
+See the [examples dir](https://github.com/EmbarkStudios/tame-webpurify/tree/main/examples) for more examples. 
 
 ## Supported methods
 

--- a/examples/check.rs
+++ b/examples/check.rs
@@ -6,7 +6,7 @@ use tame_webpurify::client::Region;
 
 mod common;
 
-/// Run as `cargo run --example profanity -- --apikey <the-api-key>`
+/// Run as `cargo run --example check -- --apikey <the-api-key>`
 #[tokio::main]
 pub async fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().collect();

--- a/examples/replace.rs
+++ b/examples/replace.rs
@@ -6,7 +6,7 @@ use tame_webpurify::client::Region;
 
 mod common;
 
-/// Run as `cargo run --example profanity -- --apikey <the-api-key>`
+/// Run as `cargo run --example replace -- --apikey <the-api-key>`
 #[tokio::main]
 pub async fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().collect();

--- a/examples/smart_screen.rs
+++ b/examples/smart_screen.rs
@@ -21,7 +21,7 @@ async fn http_send<Body: Into<reqwest::Body>>(
     Ok(builder.body(response.bytes().await?)?)
 }
 
-/// Run as `cargo run --example profanity -- --apikey <the-api-key>`
+/// Run as `cargo run --example smart_screen -- --apikey <the-api-key>`
 #[tokio::main]
 pub async fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().collect();

--- a/examples/smart_screen.rs
+++ b/examples/smart_screen.rs
@@ -1,0 +1,47 @@
+use bytes::Bytes;
+use http::Request;
+use std::env;
+use std::error::Error;
+use tame_webpurify::client;
+use tame_webpurify::client::Region;
+
+/// Return reqwest response
+async fn http_send<Body: Into<reqwest::Body>>(
+    http_client: &reqwest::Client,
+    request: Request<Body>,
+) -> Result<http::Response<Bytes>, Box<dyn Error>> {
+    // Make the request
+    let mut response = http_client.execute(request.try_into()?).await?;
+
+    // Convert to http::Response
+    let mut builder = http::Response::builder()
+        .status(response.status())
+        .version(response.version());
+    std::mem::swap(builder.headers_mut().unwrap(), response.headers_mut());
+    Ok(builder.body(response.bytes().await?)?)
+}
+
+/// Run as `cargo run --example profanity -- --apikey <the-api-key>`
+#[tokio::main]
+pub async fn main() -> Result<(), Box<dyn Error>> {
+    let args: Vec<String> = env::args().collect();
+    let api_key = args.get(2).expect("No API key provided").as_str();
+
+    let region = Region::Es;
+    // sorry for the bad language :p
+    // webpurify should filter out profanities as well as phone numbers and other contact info
+    let text = "I simply don't like you asshat. You are a potential threat and I will not accept any prisoners who get close to me. Just fuck you";
+
+    let request = client::smart_screen_request(api_key, region, text, "*")?;
+    println!("{:?}", &request.uri());
+
+    let http_client = reqwest::Client::new();
+    let response = http_send(&http_client, request).await?.into();
+
+    let result = client::smart_screen_result(response)?;
+
+    dbg!("{:?}", &result);
+
+    Ok(())
+}
+

--- a/examples/smart_screen.rs
+++ b/examples/smart_screen.rs
@@ -44,4 +44,3 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
-

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,30 +1,12 @@
+use crate::{RequestError, ResponseError};
 use http::header::CONTENT_TYPE;
 use http::{Request, Response, Uri};
-use serde_json::Value;
 use url::form_urlencoded;
 
-#[derive(thiserror::Error, Debug)]
-#[allow(clippy::upper_case_acronyms)]
-pub enum RequestError {
-    #[error("The provided Uri was invalid")]
-    InvalidUri,
-
-    #[error(transparent)]
-    HTTP(#[from] http::Error),
-}
-
-#[derive(thiserror::Error, Debug)]
-#[allow(clippy::upper_case_acronyms)]
-pub enum ResponseError {
-    #[error("The response status was invalid: {0}")]
-    HttpStatus(http::StatusCode),
-    #[error(transparent)]
-    Deserialize(#[from] serde_json::Error),
-    #[error("Missing field {0} in response")]
-    MissingField(String),
-    #[error("Invalid field {0} in response")]
-    InvalidField(String),
-}
+pub use crate::smart_screen::smart_screen_request;
+pub use crate::smart_screen::smart_screen_result;
+pub use crate::smart_screen::ApiSmartScreenResponse;
+pub use crate::smart_screen::ApiSmartScreenResponseSentiment;
 
 #[derive(Clone, Copy)]
 pub enum Region {
@@ -44,7 +26,7 @@ pub enum Method {
     SmartScreen(String, bool, bool),
 }
 
-fn api_url_by_region(region: Region) -> String {
+pub(crate) fn api_url_by_region(region: Region) -> String {
     match region {
         Region::Us => "https://api1.webpurify.com/services/rest/",
         Region::Europe => "https://api1-eu.webpurify.com/services/rest/",
@@ -58,7 +40,7 @@ fn api_url_by_region(region: Region) -> String {
 ///     Check - returns 1 if profanity is found, otherwise 0
 ///     Replace - returns 1 if profanity if found and replaces
 pub fn query_string(api_key: &str, text: &str, method: Method) -> String {
-    let method_str = match method.clone() {
+    let method_str = match method {
         Method::Check => "webpurify.live.check".to_string(),
         Method::Replace(_) => "webpurify.live.replace".to_string(),
         // TODO(mathias): Change to actually convey meaning about the args (text, sentiment, topics)
@@ -80,7 +62,7 @@ pub fn query_string(api_key: &str, text: &str, method: Method) -> String {
         qs.append_pair("replacesymbol", &replace_with);
     }
 
-    if let Method::SmartScreen(replace_with, _sentiment, _topics) = method.clone() {
+    if let Method::SmartScreen(replace_with, _sentiment, _topics) = method {
         qs.append_pair("replacesymbol", &replace_with);
         qs.append_pair("sentiment", "true");
         qs.append_pair("topics", "true");
@@ -89,11 +71,11 @@ pub fn query_string(api_key: &str, text: &str, method: Method) -> String {
     qs.finish()
 }
 
-pub(crate) fn into_uri<U: TryInto<Uri>>(uri: U) -> Result<Uri, RequestError> {
+pub fn into_uri<U: TryInto<Uri>>(uri: U) -> Result<Uri, RequestError> {
     uri.try_into().map_err(|_err| RequestError::InvalidUri)
 }
 
-fn request_builder(api_uri: String) -> Result<Request<Vec<u8>>, RequestError> {
+pub(crate) fn request_builder(api_uri: String) -> Result<Request<Vec<u8>>, RequestError> {
     let request_builder = Request::builder()
         .method("POST")
         .uri(into_uri(api_uri)?)
@@ -168,20 +150,6 @@ pub fn profanity_replace_request(
     Ok(req)
 }
 
-pub fn smart_screen_request(
-    api_key: &str,
-    region: Region,
-    text: &str,
-    replace_text: &str,
-) -> Result<Request<Vec<u8>>, RequestError> {
-    let qs = query_string(api_key, text, Method::SmartScreen(replace_text.to_string(), true, true));
-    let api_uri = format!("{}?{}", api_url_by_region(region), qs);
-
-    let req = request_builder(api_uri)?;
-    Ok(req)
-}
-
-
 #[derive(serde::Deserialize)]
 struct ApiResponse {
     rsp: ApiResponseRsp,
@@ -197,63 +165,6 @@ fn parse_response<T>(response: Response<T>) -> Result<ApiResponse, ResponseError
 where
     T: AsRef<[u8]>,
 {
-    if !response.status().is_success() {
-        return Err(ResponseError::HttpStatus(response.status()));
-    }
-
-    let body = response.body();
-    Ok(serde_json::from_slice(body.as_ref())?)
-}
-
-#[derive(Debug, serde::Deserialize)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
-pub struct ApiSmartScreenResponseSentiment {
-    text: String,
-    polarity: String,
-}
-
-#[derive(Debug, serde::Deserialize)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
-pub struct ApiSmartScreenResponse {
-    #[serde(deserialize_with="de_bool")]
-    pub bigotry: bool,
-    #[serde(deserialize_with="de_bool")]
-    pub personal_attack: bool,
-    #[serde(deserialize_with="de_bool")]
-    pub sexual_advances: bool,
-    #[serde(deserialize_with="de_bool")]
-    pub criminal_activity: bool,
-    #[serde(deserialize_with="de_bool")]
-    pub external_contact: bool,
-    #[serde(deserialize_with="de_bool")]
-    pub profanity: bool,
-    pub profanity_found: Option<Vec<String>>,
-    pub replace_text: Option<String>,
-
-    /// Only active if "topics=true" is passed to WebPurify in the query string
-    pub topics: Option<Vec<String>>,
-
-    /// Only active if "sentiment=true" is passed to WebPurify in the query string
-    pub overall_sentiment: Option<String>,
-    /// Only active if "sentiment=true" is passed to WebPurify in the query string
-    pub sentiment: Option<Vec<ApiSmartScreenResponseSentiment>>,
-}
-
-fn de_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
-    where
-        D: serde::de::Deserializer<'de>,
-{
-    let s: String = serde::de::Deserialize::deserialize(deserializer)?;
-
-    match s.as_str() {
-        "true" => Ok(true),
-        "false" => Ok(false),
-        _ => Err(serde::de::Error::unknown_variant(&s, &["true", "false"])),
-    }
-}
-
-fn parse_smart_screen_response<T>(response: Response<T>) -> Result<ApiSmartScreenResponse, ResponseError>
-where T: AsRef<[u8]>, {
     if !response.status().is_success() {
         return Err(ResponseError::HttpStatus(response.status()));
     }
@@ -303,14 +214,6 @@ where
         Some(text) => Ok(text),
         None => Err(ResponseError::MissingField("text".to_owned())),
     }
-}
-
-pub fn smart_screen_result<T>(response: Response<T>) -> Result<ApiSmartScreenResponse, ResponseError>
-where
-    T: AsRef<[u8]>,
-{
-    let res = parse_smart_screen_response(response)?;
-    Ok(res)
 }
 
 #[cfg(test)]
@@ -401,50 +304,6 @@ mod test {
         let result = client::profanity_replace_result(response)?;
 
         assert_eq!(result, "foo".to_owned());
-        Ok(())
-    }
-
-    #[test]
-    fn smart_screen_request() -> Result<(), Box<dyn Error>> {
-        let region = client::Region::Europe;
-        let req = client::smart_screen_request("abcd", region, "hi there", "*")?;
-        assert!(uri_contains(&req, "method=webpurify.live.smartscreen"));
-        assert!(uri_contains(&req, "replacesymbol=*"));
-        assert!(uri_contains(&req, "text=hi+there"));
-
-        Ok(())
-    }
-
-    #[test]
-    fn smart_screen_result() -> Result<(), Box<dyn Error>> {
-        let body = b"{\"language\":\"en\",\"bigotry\":\"false\",\"personal_attack\":\"false\",\"sexual_advances\":\"false\",\
-                                  \"criminal_activity\":\"false\",\"external_contact\":\"false\",\"mental_health\":\"false\",\"profanity\":\"true\",\
-                                  \"profanity_found\":[\"hell\"],\"replace_text\":\"To **** and back\",\"overall_sentmient\":\"negative\",\
-                                  \"sentiment\":[{\"text\":\"to hell and back\",\"polarity\":\"negative\"}]}";
-        let response = Response::builder()
-            .status(StatusCode::OK)
-            .body((*body).into_iter().collect::<Vec<_>>())?;
-        let result = client::smart_screen_result(response)?;
-
-        assert_eq!(
-            result,
-            client::ApiSmartScreenResponse {
-                bigotry: false,
-                personal_attack: false,
-                sexual_advances: false,
-                criminal_activity: false,
-                external_contact: false,
-                profanity: true,
-                profanity_found: Some(vec!["hell".to_owned()]),
-                replace_text: Some("To **** and back".to_owned()),
-                topics: None,
-                overall_sentiment: None,
-                sentiment: Some(vec![client::ApiSmartScreenResponseSentiment {
-                    text: "to hell and back".to_owned(),
-                    polarity: "negative".to_owned()
-                }])
-            }
-        );
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,3 +70,27 @@
 // crate-specific exceptions
 
 pub mod client;
+pub mod smart_screen;
+
+#[derive(thiserror::Error, Debug)]
+#[allow(clippy::upper_case_acronyms)]
+pub enum RequestError {
+    #[error("The provided Uri was invalid")]
+    InvalidUri,
+
+    #[error(transparent)]
+    HTTP(#[from] http::Error),
+}
+
+#[derive(thiserror::Error, Debug)]
+#[allow(clippy::upper_case_acronyms)]
+pub enum ResponseError {
+    #[error("The response status was invalid: {0}")]
+    HttpStatus(http::StatusCode),
+    #[error(transparent)]
+    Deserialize(#[from] serde_json::Error),
+    #[error("Missing field {0} in response")]
+    MissingField(String),
+    #[error("Invalid field {0} in response")]
+    InvalidField(String),
+}

--- a/src/smart_screen.rs
+++ b/src/smart_screen.rs
@@ -1,0 +1,147 @@
+use crate::client::api_url_by_region;
+use crate::client::query_string;
+use crate::client::request_builder;
+use crate::client::Method;
+use crate::client::Region;
+use http::{Request, Response};
+
+use crate::{RequestError, ResponseError};
+
+#[derive(Debug, serde::Deserialize)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub struct ApiSmartScreenResponseSentiment {
+    pub text: String,
+    pub polarity: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub struct ApiSmartScreenResponse {
+    #[serde(deserialize_with = "de_bool")]
+    pub bigotry: bool,
+    #[serde(deserialize_with = "de_bool")]
+    pub personal_attack: bool,
+    #[serde(deserialize_with = "de_bool")]
+    pub sexual_advances: bool,
+    #[serde(deserialize_with = "de_bool")]
+    pub criminal_activity: bool,
+    #[serde(deserialize_with = "de_bool")]
+    pub external_contact: bool,
+    #[serde(deserialize_with = "de_bool")]
+    pub profanity: bool,
+    pub profanity_found: Option<Vec<String>>,
+    pub replace_text: Option<String>,
+
+    /// Only active if "topics=true" is passed to WebPurify in the query string
+    pub topics: Option<Vec<String>>,
+
+    /// Only active if "sentiment=true" is passed to WebPurify in the query string
+    pub overall_sentiment: Option<String>,
+    /// Only active if "sentiment=true" is passed to WebPurify in the query string
+    pub sentiment: Option<Vec<ApiSmartScreenResponseSentiment>>,
+}
+
+pub fn smart_screen_request(
+    api_key: &str,
+    region: Region,
+    text: &str,
+    replace_text: &str,
+) -> Result<Request<Vec<u8>>, RequestError> {
+    let qs = query_string(
+        api_key,
+        text,
+        Method::SmartScreen(replace_text.to_string(), true, true),
+    );
+    let api_uri = format!("{}?{}", api_url_by_region(region), qs);
+
+    let req = request_builder(api_uri)?;
+    Ok(req)
+}
+
+fn de_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    let s: String = serde::de::Deserialize::deserialize(deserializer)?;
+
+    match s.as_str() {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        _ => Err(serde::de::Error::unknown_variant(&s, &["true", "false"])),
+    }
+}
+
+fn parse_smart_screen_response<T>(
+    response: Response<T>,
+) -> Result<ApiSmartScreenResponse, ResponseError>
+where
+    T: AsRef<[u8]>,
+{
+    if !response.status().is_success() {
+        return Err(ResponseError::HttpStatus(response.status()));
+    }
+
+    let body = response.body();
+    Ok(serde_json::from_slice(body.as_ref())?)
+}
+
+pub fn smart_screen_result<T>(
+    response: Response<T>,
+) -> Result<ApiSmartScreenResponse, ResponseError>
+where
+    T: AsRef<[u8]>,
+{
+    let res = parse_smart_screen_response(response)?;
+    Ok(res)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::client;
+    use http::{Response, StatusCode};
+    use std::error::Error;
+
+    #[test]
+    fn smart_screen_request() -> Result<(), Box<dyn Error>> {
+        let region = crate::client::Region::Europe;
+        let req = client::smart_screen_request("abcd", region, "hi there", "*")?;
+        assert!(uri_contains(&req, "method=webpurify.live.smartscreen"));
+        assert!(uri_contains(&req, "replacesymbol=*"));
+        assert!(uri_contains(&req, "text=hi+there"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn smart_screen_result() -> Result<(), Box<dyn Error>> {
+        let body = b"{\"language\":\"en\",\"bigotry\":\"false\",\"personal_attack\":\"false\",\"sexual_advances\":\"false\",\
+                                  \"criminal_activity\":\"false\",\"external_contact\":\"false\",\"mental_health\":\"false\",\"profanity\":\"true\",\
+                                  \"profanity_found\":[\"hell\"],\"replace_text\":\"To **** and back\",\"overall_sentmient\":\"negative\",\
+                                  \"sentiment\":[{\"text\":\"to hell and back\",\"polarity\":\"negative\"}]}";
+        let response = Response::builder()
+            .status(StatusCode::OK)
+            .body((*body).into_iter().collect::<Vec<_>>())?;
+        let result = client::smart_screen_result(response)?;
+
+        assert_eq!(
+            result,
+            client::ApiSmartScreenResponse {
+                bigotry: false,
+                personal_attack: false,
+                sexual_advances: false,
+                criminal_activity: false,
+                external_contact: false,
+                profanity: true,
+                profanity_found: Some(vec!["hell".to_owned()]),
+                replace_text: Some("To **** and back".to_owned()),
+                topics: None,
+                overall_sentiment: None,
+                sentiment: Some(vec![client::ApiSmartScreenResponseSentiment {
+                    text: "to hell and back".to_owned(),
+                    polarity: "negative".to_owned()
+                }])
+            }
+        );
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This PR adds the smart-screen part of WebPurify's API to the tame-webpurify client.

Smart Screen, in contrast to `check` and `profanity`, makes a language analysis from which it returns the likelyhood that a sentence contains `bigotry`, `personal_attack`, `sexual_advances` etc.

The full response message from WebPurify is:

```
{
  bigotry: false,                                             
  personal_attack: true,                                      
  sexual_advances: false,                                     
  criminal_activity: false,                                   
  external_contact: false,                                    
  profanity: true,                                            
  profanity_found: Some(                                      
      [                                                       
          "asshat",                                           
          "fuck",                                             
      ],                                                      
  ),                                                          
  replace_text: Some(                                         
      "I simply don't like you ******. You are a potential thr
  ),                                                          
  topics: None,                                               
  overall_sentiment: None,                                    
  sentiment: None
}                                                             
```

Note how it does *not* return the original string provided.

### Related Issues

List related issues here
