### PR TITLE
Revert "Return the number of profanities found in the `check` response"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
-### Fixed
-- [PR#13](https://github.com/EmbarkStudios/tame-webpurify/pull/13) Return the number of profanities found in the `check` response.
 
 ## [0.1.2] - 2023-05-31
 ### Added

--- a/examples/check.rs
+++ b/examples/check.rs
@@ -25,7 +25,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
 
     let result = client::profanity_check_result(response)?;
 
-    println!("Found {:?} bad words", &result);
+    println!("Found bad words: {result}");
 
     Ok(())
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -266,7 +266,8 @@ where
 {
     let response = parse_response(response, Method::Check)?;
 
-    let check: u32 = response
+    // Note, `found` is a boolean in the form of an integer, see: https://www.webpurify.com/documentation/methods/check/
+    let found: u32 = response
         .rsp
         .found
         .ok_or_else(|| ResponseError::MissingField("found".to_owned()))
@@ -276,7 +277,7 @@ where
                 .map_err(|_err| ResponseError::InvalidField("found".to_owned()))
         })?;
 
-    Ok(check > 0)
+    Ok(found > 0)
 }
 
 /// Returns the sanitized string from a response object.

--- a/src/client.rs
+++ b/src/client.rs
@@ -253,19 +253,20 @@ where
 
     Ok(api_response)
 }
-/// Returns the number of profanities, PII etc `WebPurify` matched in the input string.
+
+/// Returns true if `WebPurify` flagged a request to contain profanities, PII, etc
 ///
 /// # Arguments
 ///
 /// * `response` - a response object from the `WebPurify` `check` API call
 ///
-pub fn profanity_check_result<T>(response: Response<T>) -> Result<u32, ResponseError>
+pub fn profanity_check_result<T>(response: Response<T>) -> Result<bool, ResponseError>
 where
     T: AsRef<[u8]>,
 {
     let response = parse_response(response, Method::Check)?;
 
-    let found: u32 = response
+    let check: u32 = response
         .rsp
         .found
         .ok_or_else(|| ResponseError::MissingField("found".to_owned()))
@@ -275,7 +276,7 @@ where
                 .map_err(|_err| ResponseError::InvalidField("found".to_owned()))
         })?;
 
-    Ok(found)
+    Ok(check > 0)
 }
 
 /// Returns the sanitized string from a response object.
@@ -336,9 +337,9 @@ mod test {
                 .body(body.as_bytes().to_vec())
         };
         let result = client::profanity_check_result(response_found(3)?)?;
-        assert_eq!(result, 3);
+        assert!(result);
         let result = client::profanity_check_result(response_found(0)?)?;
-        assert_eq!(result, 0);
+        assert!(!result);
         Ok(())
     }
 


### PR DESCRIPTION
Reverts EmbarkStudios/tame-webpurify#13

Looking at https://www.webpurify.com/documentation/methods/check/ it seem the webpurify API only returns 0 or 1 if profanities are found so this change does not make sense.